### PR TITLE
Pad fractional component up to requested number of digits

### DIFF
--- a/Data/Time/RFC3339.hs
+++ b/Data/Time/RFC3339.hs
@@ -65,7 +65,9 @@ formatTimeRFC3339Fractional mn zt@(ZonedTime _ z) =
                     else take 3 timeZoneStr <> ":" <> drop 3 timeZoneStr
         trunc = case mn of
                 Nothing -> id
-                Just n -> if n <= 0 then const "" else take (n+1)
+                Just n
+                  | n <= 0    -> const ""
+                  | otherwise -> \s -> take (n+1) (s <> repeat '0')
         truncFrac = fromString $ trunc (formatTime defaultTimeLocale "%Q" zt)
 
 formatsRFC3339 :: [Text]


### PR DESCRIPTION
Before this change, `trunc` produced `String`s shorter than the requested number of digits (whenever `formatTime`'s output was shorter). This behavior mis-aligns columns of timestamps in logs, which is distracting.

After this change, additional zeros are appended as needed so that the fractional component is always the requested  length when length >= 1.